### PR TITLE
Changing deprecated template name

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,7 +31,7 @@
 		{{- template "_internal/twitter_cards.html" . -}}
 
 		{{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}
-			{{ template "_internal/google_analytics_async.html" . }}
+			{{ template "_internal/google_analytics.html" . }}
 		{{ end }}
 	</head>
 


### PR DESCRIPTION
The internal template `google_analytics_async` was deprecated and changed to `google_analytics`

https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410